### PR TITLE
Fix for development environments without RACK_ENV or RAILS_ENV (like Pow)

### DIFF
--- a/lib/glimpse.rb
+++ b/lib/glimpse.rb
@@ -12,9 +12,9 @@ module Glimpse
   end
 
   def self.env
-    ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    Rails.env
   end
-
+  
   def self.views
     @cached_views ||= if @views && @views.any?
       @views.collect { |klass, options| klass.new(options.dup) }.select(&:enabled?)


### PR DESCRIPTION
Just using Rails.env here, which defaults to 'development' when both environment variables are missing.
