### PR TITLE
Namespace tooltip class name

### DIFF
--- a/app/assets/javascripts/glimpse.coffee
+++ b/app/assets/javascripts/glimpse.coffee
@@ -8,7 +8,7 @@ updatePerformanceBar = ->
     $(this).text data
 
 initializeTipsy = ->
-  $('#glimpse .tooltip').each ->
+  $('#glimpse .glimpse-tooltip, #glimpse .tooltip').each ->
     el = $(this)
     gravity = if el.hasClass('rightwards') then 'w' else 'n'
     gravity = if el.hasClass('leftwards') then 'e' else gravity


### PR DESCRIPTION
Using the tooltip class name is fairly generic and other applications may already have preexisting styles applied to it. Use `glimpse-tooltip` instead.

/cc dewski/glimpse-performance_bar#8
