### PR TITLE
[doc] Require peek before trapping it for CI build situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ For best results with Spork, add this to your `prefork` block
 anytime before your environment is loaded:
 
 ```ruby
+require 'peek'
 Spork.trap_class_method(Peek, :setup)
 ```
 


### PR DESCRIPTION
One more documentation fix. This bit us on CI due to bundler differences and might bite others. Give a hoot, save an issue.
