### PR TITLE
Update peek.coffee for greater browser compatibility

### DIFF
--- a/app/assets/javascripts/peek.coffee
+++ b/app/assets/javascripts/peek.coffee
@@ -28,7 +28,7 @@ initializeTipsy = ->
 toggleBar = (event) ->
   return if $(event.target).is ':input'
 
-  if event.keyCode == 96 && !event.metaKey
+  if event.which == 96 && !event.metaKey
     wrapper = $('#peek')
     if wrapper.hasClass 'disabled'
       wrapper.removeClass 'disabled'


### PR DESCRIPTION
In the toggleBar function, since this is a jQuery.Event object we can use the event.which property to get the normalized keyCode|charCode property allowing greater cross-browser support.

The main reason for the change was that while using peek, Firefox users on Linux could not use the keyboard shortcut to toggle the peek bar. Tracing showed that FF linux event.keyCode was returning 0 while event.which correctly returns 96. [I've referenced this documentation in jQuery to make this choice.](http://api.jquery.com/event.which/) Thanks! 
