### PR TITLE
request.uuid is not defined in Rails 3.1.

### DIFF
--- a/lib/peek/controller_helpers.rb
+++ b/lib/peek/controller_helpers.rb
@@ -10,7 +10,7 @@ module Peek
     protected
 
     def set_peek_request_id
-      Peek.request_id = request.uuid
+      Peek.request_id = request.methods.include?(:uuid) ? request.uuid : env['action_dispatch.request_id']
     end
 
     def peek_enabled?


### PR DESCRIPTION
It looks like Rails 3.1 apps blow up since the request object did not gain uuid method until Rails 3.2. I added a small check to see if the uuid method exists and, if it doesn't, it falls back to the old environment variable.

Everything looked solid on my company's Rails 3.1.12 app once I made the change on my fork.
