### PR TITLE
Update peek.scss

### DIFF
--- a/app/assets/stylesheets/peek.scss
+++ b/app/assets/stylesheets/peek.scss
@@ -29,7 +29,7 @@
   }
 
   .wrapper {
-    width: 800px;
+    width: 100%;
     margin: 0px 20% auto;
   }
 


### PR DESCRIPTION
![peek css](https://f.cloud.github.com/assets/181256/1274293/c1a9a45a-2d8d-11e3-8ac1-26ef522ab22b.png)
Peek css breaks when too many plugins are enabled.

My frontend skills aren't the best and there may be a better way to solve this. I tried this and it worked for me.
