### PR TITLE
Include the ControllerHelpers directly into `ActionController::Base`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,6 @@ It just works.
 
 It just works.
 
-## Using Peek with Spork
-
-For best results with Spork, add this to your `prefork` block
-anytime before your environment is loaded:
-
-```ruby
-require 'peek'
-Spork.trap_class_method(Peek, :setup)
-```
-
 ## Access Control
 
 Peek will only render in development and staging environments. If you'd

--- a/lib/peek.rb
+++ b/lib/peek.rb
@@ -103,7 +103,7 @@ module Peek
   end
 
   def self.setup
-    ApplicationController.send(:include, Peek::ControllerHelpers)
+    ActiveSupport::Deprecation.warn "'Peek.setup' is deprecated and does nothing.", caller
   end
 end
 

--- a/lib/peek/railtie.rb
+++ b/lib/peek/railtie.rb
@@ -26,8 +26,11 @@ module Peek
     end
 
     initializer 'peek.include_controller_helpers' do
+      ActiveSupport.on_load(:action_controller) do
+        include Peek::ControllerHelpers
+      end
+
       config.to_prepare do
-        Peek.setup
         Peek.views
       end
     end


### PR DESCRIPTION
Including on `ApplicationController` won't affect controllers inside engines,
and breaks such controllers when used with `peek-rblineprof` as it extends
`AC::Base` directly.

This also makes the Spork specific setup and the `Peek.setup` API unnecessary.
