### PR TITLE
Rescue & log Dalli exceptions instead of crashing

### DIFF
--- a/lib/peek/adapters/memcache.rb
+++ b/lib/peek/adapters/memcache.rb
@@ -11,10 +11,14 @@ module Peek
 
       def get(request_id)
         @client.get("peek:requests:#{request_id}")
+      rescue ::Dalli::DalliError => e
+        Rails.logger.error "#{e.class.name}: #{e.message}"
       end
 
       def save
         @client.add("peek:requests:#{Peek.request_id}", Peek.results.to_json, @expires_in)
+      rescue ::Dalli::DalliError => e
+        Rails.logger.error "#{e.class.name}: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
Losing access to Memcache shouldn't cause a production environment to fail entirely. Using Peek with Memcache runs this risk. To solve the problem, Dalli errors should be rescued and logged. The Peek toolbar won't show any data, of course, but the application will still be allowed to respond.
