### PR TITLE
Depend on `railties` and not `rails`.

### DIFF
--- a/peek.gemspec
+++ b/peek.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'rails',  '>= 3.0.0'
-  gem.add_dependency 'atomic', '>= 1.0.0'
+  gem.add_dependency 'railties', '>= 3.0.0'
+  gem.add_dependency 'atomic',   '>= 1.0.0'
 end


### PR DESCRIPTION
The `rails` gem is a meta gem to glue all the other ones together
and shouldn't be used as a runtime dependency of other gems.
This way Peek won't bring `activerecord` or `arel` as dependency
on applications that aren't using Active Record.
