### PR TITLE
[adapters/memcache] swallow RingError exception

### DIFF
--- a/lib/peek/adapters/memcache.rb
+++ b/lib/peek/adapters/memcache.rb
@@ -11,10 +11,14 @@ module Peek
 
       def get(request_id)
         @client.get("peek:requests:#{request_id}")
+      rescue ::Dalli::RingError
+        # pass
       end
 
       def save
         @client.add("peek:requests:#{Peek.request_id}", Peek.results.to_json, @expires_in)
+      rescue ::Dalli::RingError
+        # pass
       end
     end
   end


### PR DESCRIPTION
Currently, if memcache is not available peek will 500 your app.
I believe peek is not _essential_ functionality and should not bring
down your app. I would like to print an error, though currently there is
no defined pattern of where to print and I'm not ready to $STDERR.puts
yet.
