### PR TITLE
Document adding margin-bottom to body when peek is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ You can customize the appearance of the bar by customizing it in your own applic
 One common example is fixing the peek bar to the bottom, rather than top, of a page, for use with [Bootstrap](http://getbootstrap.com/):
 
 ```css
+body.peek-enabled {
+  margin-bottom: 35px;
+}
+
 #peek {
   position: fixed;
   bottom: 0;
@@ -169,6 +173,10 @@ One common example is fixing the peek bar to the bottom, rather than top, of a p
   right: 0;
   z-index: 999;
 }
+```
+
+```javascript
+$('#peek').parent().addClass('peek-enabled');
 ```
 
 ## Using Peek with PJAX


### PR DESCRIPTION
This is a followup to https://github.com/peek/peek/pull/52

If you have more content than can fit on a single page, peek would end up covering up the bottom-most content. This recommends making a body class to indicate peek's enabled, then when peek is present, applying that class.

It might be simpler to get peek's height and automatically add that to body though.
