### PR TITLE
Remove responders

### DIFF
--- a/app/controllers/peek/results_controller.rb
+++ b/app/controllers/peek/results_controller.rb
@@ -1,13 +1,16 @@
 module Peek
   class ResultsController < ApplicationController
     before_filter :restrict_non_access
-    respond_to :json
 
     def show
-      if request.xhr?
-        render :json => Peek.adapter.get(params[:request_id])
-      else
-        render :nothing => true, :status => :not_found
+      respond_to do |format|
+        format.json do
+          if request.xhr?
+            render :json => Peek.adapter.get(params[:request_id])
+          else
+            render :nothing => true, :status => :not_found
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Responders are [deprecated in Rails 4.2][1] so we remove the class-level
call to `respond_to`.

[1]: http://edgeguides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to