### PR TITLE
Update gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'json', '~> 1.7.7'
+gem 'json', '~> 1.8.2'
 
 gem 'rails', '~> 4.0.0.rc1'
 

--- a/lib/peek.rb
+++ b/lib/peek.rb
@@ -1,6 +1,6 @@
 require 'peek/version'
 require 'rails'
-require 'atomic'
+require 'concurrent/atomics'
 
 require 'peek/adapters/memory'
 require 'peek/views/view'
@@ -9,7 +9,7 @@ module Peek
   ALLOWED_ENVS = ['development', 'staging'].freeze
 
   def self._request_id
-    @_request_id ||= Atomic.new
+    @_request_id ||= Concurrent::Atomic.new
   end
 
   def self.request_id

--- a/peek.gemspec
+++ b/peek.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'atomic',   '>= 1.0.0'
+  gem.add_dependency 'concurrent-ruby', '>= 0.8.0'
+  gem.add_dependency 'concurrent-ruby-ext', '>= 0.8.0'
 end


### PR DESCRIPTION
This PR updates 2 gems.

 * json - updates to 1.8.2 because this version is compatible with ruby 2.2.2
 * atomic - change to use [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) because atomic gem is deprecated, and it is recommended way.