### PR TITLE
Process action filter

### DIFF
--- a/lib/peek.rb
+++ b/lib/peek.rb
@@ -48,6 +48,14 @@ module Peek
     @adapter
   end
 
+  def self.process_action_filter
+    @process_action_filter
+  end
+
+  def self.process_action_filter=(callable)
+    @process_action_filter = callable
+  end
+
   def self.enabled?
     ALLOWED_ENVS.include?(env)
   end


### PR DESCRIPTION
I have a rails app where I am using Peek in production and set `peek_enabled?` to only show for admin users. I was surprised to find out that `Peek.results` are computed for every request, regardless of the return value of `peek_enabled?`. I am using peek-resque as well, and this adds a significant load to my production redis instance.

The comment here https://github.com/peek/peek/issues/71#issuecomment-111280956, leads me to believe that Peek is not recommended for use in production, but I would like to continue using it.

The code in this PR is a proof of concept for selectively not computing results on certain requests. Adding the following config successfully disables result computation for a specific endpoint:
```ruby
Application.configure do
  config.peek.process_action_filter = Proc.new do |request_payload|
    request_payload[:path] != '/api/user'
  end
end
```

And an example request_payload (what we can filter on):
```ruby
{:controller=>"SiteController",
  :action=>"home",
  :params=>{"controller"=>"site", "action"=>"home"},
  :format=>:html,
  :method=>"GET",
  :path=>"/",
  :status=>200,
  :view_runtime=>209.131,
  :db_runtime=>2.489}
```

Having a filtering feature like this would allow me to continue to use Peek in production. Would you consider expanding on this idea and merging? 

Cheers!