### PR TITLE
Results by cookie

### DIFF
--- a/app/assets/javascripts/peek.coffee
+++ b/app/assets/javascripts/peek.coffee
@@ -16,6 +16,10 @@ do ($ = jQuery) ->
         $("[data-defer-to=#{key}-#{label}]").text results.data[key][label]
     $(document).trigger 'peek:render', [getRequestId(), results]
 
+  updateNoResults = ->
+   $('[data-defer-to]').parents('.view').addClass('hidden')
+   $('#peek-no-results').removeClass('hidden')
+
   initializeTipsy = ->
     $('#peek .peek-tooltip, #peek .tooltip').each ->
       el = $(this)
@@ -44,7 +48,10 @@ do ($ = jQuery) ->
       data:
         request_id: getRequestId()
       success: (data, textStatus, xhr) ->
-        updatePerformanceBar data
+        if data?
+          updatePerformanceBar data
+        else
+          updateNoResults()
       error: (xhr, textStatus, error) ->
         # Swallow the error
 

--- a/app/assets/javascripts/peek.coffee
+++ b/app/assets/javascripts/peek.coffee
@@ -34,10 +34,10 @@ do ($ = jQuery) ->
       wrapper = $('#peek')
       if wrapper.hasClass 'disabled'
         wrapper.removeClass 'disabled'
-        document.cookie = "peek=true; path=/";
+        setPeekEnabledCookie(true)
       else
         wrapper.addClass 'disabled'
-        document.cookie = "peek=false; path=/";
+        setPeekEnabledCookie(false)
 
   fetchRequestResults = ->
     $.ajax '/peek/results',
@@ -48,6 +48,9 @@ do ($ = jQuery) ->
       error: (xhr, textStatus, error) ->
         # Swallow the error
 
+  setPeekEnabledCookie = (enabled) ->
+    document.cookie = "peek=#{!!enabled}; path=/";
+
   $(document).on 'keypress', toggleBar
 
   $(document).on 'peek:update', initializeTipsy
@@ -57,7 +60,6 @@ do ($ = jQuery) ->
   $(document).on 'pjax:end', (event, xhr, options) ->
     if xhr?
       requestId = xhr.getResponseHeader 'X-Request-Id'
-
     if peekEnabled()
       $(this).trigger 'peek:update'
 
@@ -68,4 +70,5 @@ do ($ = jQuery) ->
 
   $ ->
     if peekEnabled()
+      setPeekEnabledCookie(true)
       $(this).trigger 'peek:update'

--- a/app/views/peek/_bar.html.erb
+++ b/app/views/peek/_bar.html.erb
@@ -6,6 +6,9 @@
         <%= render view.partial_path, :view => view %>
       </div>
     <% end %>
+    <div id="peek-no-results" class="hidden view">
+      Refresh to view more results.
+    </div>
   </div>
 </div>
 <% end %>

--- a/lib/peek/controller_helpers.rb
+++ b/lib/peek/controller_helpers.rb
@@ -9,6 +9,11 @@ module Peek
 
     protected
 
+    def append_info_to_payload(payload)
+      super
+      payload[:peek_enabled] = request.cookies['peek'] == 'true'
+    end
+
     def set_peek_request_id
       Peek.request_id = env['action_dispatch.request_id']
     end

--- a/lib/peek/railtie.rb
+++ b/lib/peek/railtie.rb
@@ -20,8 +20,11 @@ module Peek
 
     initializer 'peek.persist_request_data' do
       ActiveSupport::Notifications.subscribe('process_action.action_controller') do
-        Peek.adapter.save
-        Peek.clear
+        |_, _, _, _, payload|
+        if payload[:peek_enabled]
+          Peek.adapter.save
+          Peek.clear
+        end
       end
     end
 

--- a/test/controllers/requests_test.rb
+++ b/test/controllers/requests_test.rb
@@ -1,14 +1,30 @@
 require 'test_helper'
 
 class RequestsTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::MethodCallAssertions
+
   setup do
     Peek.adapter.reset
     Peek.reset
   end
 
-  test "the request id is set" do
+  test "the request id is set when the peek cookie is set" do
     assert_empty Peek.adapter.requests
+    cookies['peek'] = 'true'
     get '/'
     assert_not_empty Peek.adapter.requests
+  end
+
+  test "saves results if the peek cookie is set" do
+    cookies['peek'] = 'true'
+    assert_called(Peek.adapter, :save) do
+      get '/'
+    end
+  end
+
+  test "does not save results if the peek cookie is not set" do
+    assert_not_called(Peek.adapter, :save) do
+      get '/'
+    end
   end
 end

--- a/test/support/method_call_assertions.rb
+++ b/test/support/method_call_assertions.rb
@@ -1,0 +1,42 @@
+# Taken from ActiveSupport testing help targeting Rails 5
+# https://github.com/rails/rails/blob/f50d953ff646b84a1c791a8034cfb4f3789fc8bf/activesupport/lib/active_support/testing/method_call_assertions.rb
+
+module ActiveSupport
+  module Testing
+    module MethodCallAssertions # :nodoc:
+      private
+        def assert_called(object, method_name, message = nil, times: 1, returns: nil)
+          times_called = 0
+
+          object.stub(method_name, proc { times_called += 1; returns }) { yield }
+
+          error = "Expected #{method_name} to be called #{times} times, " \
+            "but was called #{times_called} times"
+          error = "#{message}.\n#{error}" if message
+          assert_equal times, times_called, error
+        end
+
+        def assert_called_with(object, method_name, args = [], returns: nil)
+          mock = Minitest::Mock.new
+
+          if args.all? { |arg| arg.is_a?(Array) }
+            args.each { |arg| mock.expect(:call, returns, arg) }
+          else
+            mock.expect(:call, returns, args)
+          end
+
+          object.stub(method_name, mock) { yield }
+
+          mock.verify
+        end
+
+        def assert_not_called(object, method_name, message = nil, &block)
+          assert_called(object, method_name, message, times: 0, &block)
+        end
+
+        def stub_any_instance(klass, instance: klass.new)
+          klass.stub(:new, instance) { yield instance }
+        end
+    end
+  end
+end


### PR DESCRIPTION
Hi @deski -  Following up on our discussion in #78 

This PR adds info from the peek cookie as discussed. It does not save Peek results unless the peek cookie is enabled. Always sets the cookie if peek is enabled.

In the case Peek was not enabled for a request, and is toggled on, `Peek::Views` with a `data-defer-to` are hidden and a refresh message is displayed: 

![screen shot 2015-10-12 at 8 41 31 pm](https://cloud.githubusercontent.com/assets/283496/10442611/22bb6a2e-7122-11e5-8fb3-c3fb5ed333b7.png)



