### PR TITLE
Add dependency for 'coffee-rails'

### DIFF
--- a/peek.gemspec
+++ b/peek.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'railties', '>= 3.0.0'
   gem.add_dependency 'concurrent-ruby', '>= 0.8.0'
   gem.add_dependency 'concurrent-ruby-ext', '>= 0.8.0'
+  gem.add_dependency 'coffee-rails'
 end


### PR DESCRIPTION
I tried to use Peak on a project that doesn't use CoffeeScript, and Rails (understandably) didn't know what to do with the `.coffee` file from this gem. I solved it by adding it manually to my Gemfile, but it should really be here instead. 

I'm not sure what version is needed, so I didn't specify one.