### PR TITLE
Allow richer tooltips with html

### DIFF
--- a/app/assets/javascripts/peek.coffee
+++ b/app/assets/javascripts/peek.coffee
@@ -23,9 +23,10 @@ do ($ = jQuery) ->
         $.fn.tipsy.autoWE
       else
         $.fn.tipsy.autoNS
-
+      html = el.hasClass('html')
       el.tipsy
         gravity: gravity
+        html: html
 
   toggleBar = (event) ->
     return if $(event.target).is ':input'


### PR DESCRIPTION
Sometimes a little bold, or a break, might make some information more palatable.

<img width="202" alt="screenshot 2015-11-08 11 28 44" src="https://cloud.githubusercontent.com/assets/14028/11018079/e70f101c-860b-11e5-9c23-11bd83c2a972.png">

/cc @twe4ked @jacobbednarz 
