### PR TITLE
Compatibility with new version Rails and Concurrent Ruby

### DIFF
--- a/lib/peek.rb
+++ b/lib/peek.rb
@@ -9,7 +9,7 @@ module Peek
   ALLOWED_ENVS = ['development', 'staging'].freeze
 
   def self._request_id
-    @_request_id ||= Concurrent::Atomic.new
+    @_request_id ||= Concurrent::AtomicReference.new
   end
 
   def self.request_id

--- a/lib/peek/controller_helpers.rb
+++ b/lib/peek/controller_helpers.rb
@@ -4,7 +4,7 @@ module Peek
 
     included do
       prepend_before_action :set_peek_request_id, :if => :peek_enabled?
-      helper_method :peek_enabled?
+      helper_method :peek_enabled? if respond_to? :helper_method
     end
 
     protected

--- a/peek.gemspec
+++ b/peek.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'concurrent-ruby', '>= 0.8.0'
-  gem.add_dependency 'concurrent-ruby-ext', '>= 0.8.0'
+  gem.add_dependency 'concurrent-ruby', '>= 0.9.0'
+  gem.add_dependency 'concurrent-ruby-ext', '>= 0.9.0'
   gem.add_dependency 'coffee-rails'
 end


### PR DESCRIPTION
This PR adds compatibility with rails 5.0.0.beta1 and concurrent-ruby 1.0.

1. `Concurrent::Atomic` is deprecated and instead need to use `Concurrent::AtomicReference` ([#277](https://github.com/ruby-concurrency/concurrent-ruby/pull/277));

2. In rails 5 added `ActionController::API`, which does not have a method` helper_method`, which is why the following error:

```
/Users/mgrachev/matchmaking/vendor/bundle/gems/peek-0.1.10/lib/peek/controller_helpers.rb:7:in `block in <module:ControllerHelpers>': undefined method `helper_method' for ActionController::API:Class (NoMethodError)
        from /Users/mgrachev/matchmaking/vendor/bundle/gems/activesupport-5.0.0.beta1/lib/active_support/concern.rb:120:in `class_eval'
        from /Users/mgrachev/matchmaking/vendor/bundle/gems/activesupport-5.0.0.beta1/lib/active_support/concern.rb:120:in `append_features'
        from /Users/mgrachev/matchmaking/vendor/bundle/gems/peek-0.1.10/lib/peek/railtie.rb:30:in `include'
        from /Users/mgrachev/matchmaking/vendor/bundle/gems/peek-0.1.10/lib/peek/railtie.rb:30:in `block (2 levels) in <class:Railtie>'
```