### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+before_install:
+  - gem install bundler


### PR DESCRIPTION
Travis CI build not complete on my last PR #83 due to the following error:

```ruby
NoMethodError: undefined method `spec' for nil:NilClass
```

This PR fixes it.