### PR TITLE
Remove deprecation warnings

### DIFF
--- a/lib/peek/controller_helpers.rb
+++ b/lib/peek/controller_helpers.rb
@@ -3,14 +3,14 @@ module Peek
     extend ActiveSupport::Concern
 
     included do
-      prepend_before_filter :set_peek_request_id, :if => :peek_enabled?
+      prepend_before_action :set_peek_request_id, :if => :peek_enabled?
       helper_method :peek_enabled?
     end
 
     protected
 
     def set_peek_request_id
-      Peek.request_id = env['action_dispatch.request_id']
+      Peek.request_id = request.env['action_dispatch.request_id']
     end
 
     def peek_enabled?


### PR DESCRIPTION
Use method `prepend_before_action` instead `prepend_before_filter` and
`request.env` instead `env`.

```ruby
DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead. (called from block in <module:ControllerHelpers> at /Users/mgrachev/peek/lib/peek/controller_helpers.rb:6)
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.0. (called from set_peek_request_id at /Users/mgrachev/peek/lib/peek/controller_helpers.rb:13)
```