### PR TITLE
Listen to Turbolinks 5 `turbolinks:load` event.

### DIFF
--- a/app/assets/javascripts/peek.coffee
+++ b/app/assets/javascripts/peek.coffee
@@ -62,7 +62,7 @@ do ($ = jQuery) ->
       $(this).trigger 'peek:update'
 
   # Also listen to turbolinks page change event
-  $(document).on 'page:change', ->
+  $(document).on 'page:change turbolinks:load', ->
     if peekEnabled()
       $(this).trigger 'peek:update'
 


### PR DESCRIPTION
Turbolinks 5 uses `turbolinks:load` instead of `page:change` for page re-renders.