### PR TITLE
Updated README to include Flexirest Peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ end
 - [peek-dalli](https://github.com/peek/peek-dalli)
 - [peek-delayed_job](https://github.com/18F/peek-delayed_job)
 - [peek-faraday](https://github.com/grk/peek-faraday)
+- [peek-flexirest](https://github.com/andyjeffries/peek-flexirest)
 - [peek-gc](https://github.com/peek/peek-gc)
 - [peek-git](https://github.com/peek/peek-git)
 - [peek-host](https://github.com/jacobbednarz/peek-host)


### PR DESCRIPTION
Flexirest is for accessing REST services in an ActiveRecord style. ActiveResource already exists for this, but it doesn't work where the resource naming doesn't follow Rails conventions, it doesn't have in-built caching and it's not as flexible in general.  It's a supported fork of ActiveRestClient.

I've just created a Peek gem for it.