### PR TITLE
Don't store metrics if Peek.request_id is blank

### DIFF
--- a/lib/peek/adapters/elasticsearch.rb
+++ b/lib/peek/adapters/elasticsearch.rb
@@ -19,6 +19,8 @@ module Peek
       end
 
       def save(request_id)
+        return false if request_id.blank?
+
         @client.index index: @index,
                       type: @type,
                       id: "#{request_id}",

--- a/lib/peek/adapters/memcache.rb
+++ b/lib/peek/adapters/memcache.rb
@@ -16,6 +16,8 @@ module Peek
       end
 
       def save(request_id)
+        return false if request_id.blank?
+
         @client.add("peek:requests:#{request_id}", Peek.results.to_json, @expires_in)
       rescue ::Dalli::DalliError => e
         Rails.logger.error "#{e.class.name}: #{e.message}"

--- a/lib/peek/adapters/memory.rb
+++ b/lib/peek/adapters/memory.rb
@@ -14,6 +14,8 @@ module Peek
       end
 
       def save(request_id)
+        return false if request_id.blank?
+
         @requests[request_id] = Peek.results
       end
 

--- a/lib/peek/adapters/redis.rb
+++ b/lib/peek/adapters/redis.rb
@@ -14,6 +14,8 @@ module Peek
       end
 
       def save(request_id)
+        return false if request_id.blank?
+
         @client.setex("peek:requests:#{request_id}", @expires_in, Peek.results.to_json)
       end
     end

--- a/lib/peek/railtie.rb
+++ b/lib/peek/railtie.rb
@@ -20,7 +20,9 @@ module Peek
 
     initializer 'peek.persist_request_data' do
       ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, _start, _finish, _id, payload|
-        Peek.adapter.save(payload[:headers].env['action_dispatch.request_id'])
+        if request_id = payload[:headers].env['action_dispatch.request_id']
+          Peek.adapter.save(request_id)
+        end
       end
     end
 


### PR DESCRIPTION
When `Peek.request_id` is blank, it means Peek isn't enabled for the current request, so there's no need to save the metrics in the adapter in that case.

We believe that led to a performance degradation on GitLab.com today: https://gitlab.com/gitlab-com/gl-infra/production/issues/936#note_188001426

Closes https://github.com/peek/peek/issues/56.