### PR TITLE
Remove Peek.request_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,7 @@
   - Replace GIFs with colors @tarebyte
 - Remove CoffeeScript @dewski
 - Use Ruby JSON syntax for hashes
+
+# Next
+
+- Ensure that Peek can handle concurrent requests with a multithreaded application server

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ gemspec
 gem 'rake'
 gem 'json', '~> 2.0', '>= 2.0.2'
 
+# For the test application
 gem 'rails', '~> 5.0', '>= 5.0.0.1'
+gem 'concurrent-ruby', '>= 0.9.0'
+gem 'concurrent-ruby-ext', '>= 0.9.0'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'

--- a/app/views/peek/_bar.html.erb
+++ b/app/views/peek/_bar.html.erb
@@ -1,5 +1,5 @@
 <% if peek_enabled? %>
-<div id="peek" class="<%= Peek.env %><%= ' disabled' if cookies[:peek] == 'false' %>" data-request-id="<%= Peek.request_id %>">
+<div id="peek" class="<%= Peek.env %><%= ' disabled' if cookies[:peek] == 'false' %>" data-request-id="<%= peek_request_id %>">
   <div class="wrapper">
     <% Peek.views.each do |view| %>
       <div id="<%= view.dom_id %>" class="view">

--- a/lib/peek.rb
+++ b/lib/peek.rb
@@ -1,24 +1,11 @@
 require 'peek/version'
 require 'rails'
-require 'concurrent/atomics'
 
 require 'peek/adapters/memory'
 require 'peek/views/view'
 
 module Peek
   ALLOWED_ENVS = ['development', 'staging'].freeze
-
-  def self._request_id
-    @_request_id ||= Concurrent::AtomicReference.new
-  end
-
-  def self.request_id
-    _request_id.get
-  end
-
-  def self.request_id=(id)
-    _request_id.update { id }
-  end
 
   def self.adapter
     @adapter
@@ -94,14 +81,6 @@ module Peek
   def self.reset
     @views = nil
     @cached_views = nil
-  end
-
-  # Hook that happens after every request. It is expected to reset
-  # any state that Peek managed throughout the requests lifecycle.
-  #
-  # Returns nothing.
-  def self.clear
-    _request_id.update { '' }
   end
 
   def self.setup

--- a/lib/peek/adapters/elasticsearch.rb
+++ b/lib/peek/adapters/elasticsearch.rb
@@ -18,10 +18,10 @@ module Peek
         # pass
       end
 
-      def save
+      def save(request_id)
         @client.index index: @index,
                       type: @type,
-                      id: "#{Peek.request_id}",
+                      id: "#{request_id}",
                       body: Peek.results.to_json,
                       ttl: @expires_in
       rescue ::Elasticsearch::Transport::Transport::Errors::BadRequest

--- a/lib/peek/adapters/memcache.rb
+++ b/lib/peek/adapters/memcache.rb
@@ -15,8 +15,8 @@ module Peek
         Rails.logger.error "#{e.class.name}: #{e.message}"
       end
 
-      def save
-        @client.add("peek:requests:#{Peek.request_id}", Peek.results.to_json, @expires_in)
+      def save(request_id)
+        @client.add("peek:requests:#{request_id}", Peek.results.to_json, @expires_in)
       rescue ::Dalli::DalliError => e
         Rails.logger.error "#{e.class.name}: #{e.message}"
       end

--- a/lib/peek/adapters/memory.rb
+++ b/lib/peek/adapters/memory.rb
@@ -13,8 +13,8 @@ module Peek
         @requests[request_id]
       end
 
-      def save
-        @requests[Peek.request_id] = Peek.results
+      def save(request_id)
+        @requests[request_id] = Peek.results
       end
 
       def reset

--- a/lib/peek/adapters/redis.rb
+++ b/lib/peek/adapters/redis.rb
@@ -13,8 +13,8 @@ module Peek
         @client.get("peek:requests:#{request_id}")
       end
 
-      def save
-        @client.setex("peek:requests:#{Peek.request_id}", @expires_in, Peek.results.to_json)
+      def save(request_id)
+        @client.setex("peek:requests:#{request_id}", @expires_in, Peek.results.to_json)
       end
     end
   end

--- a/lib/peek/controller_helpers.rb
+++ b/lib/peek/controller_helpers.rb
@@ -3,18 +3,20 @@ module Peek
     extend ActiveSupport::Concern
 
     included do
-      prepend_before_action :set_peek_request_id, if: :peek_enabled?
-      helper_method :peek_enabled? if respond_to? :helper_method
+      if respond_to? :helper_method
+        helper_method :peek_enabled?
+        helper_method :peek_request_id
+      end
     end
 
     protected
 
-    def set_peek_request_id
-      Peek.request_id = request.env['action_dispatch.request_id']
-    end
-
     def peek_enabled?
       Peek.enabled?
+    end
+
+    def peek_request_id
+      request.env['action_dispatch.request_id']
     end
   end
 end

--- a/lib/peek/railtie.rb
+++ b/lib/peek/railtie.rb
@@ -19,9 +19,8 @@ module Peek
     end
 
     initializer 'peek.persist_request_data' do
-      ActiveSupport::Notifications.subscribe('process_action.action_controller') do
-        Peek.adapter.save
-        Peek.clear
+      ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, _start, _finish, _id, payload|
+        Peek.adapter.save(payload[:headers].env['action_dispatch.request_id'])
       end
     end
 

--- a/peek.gemspec
+++ b/peek.gemspec
@@ -19,6 +19,4 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'railties', '>= 4.0.0'
-  gem.add_dependency 'concurrent-ruby', '>= 0.9.0'
-  gem.add_dependency 'concurrent-ruby-ext', '>= 0.9.0'
 end

--- a/test/controllers/requests_test.rb
+++ b/test/controllers/requests_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require_relative '../dummy/lib/test_view'
 
 class RequestsTest < ActionDispatch::IntegrationTest
   setup do
@@ -8,7 +9,25 @@ class RequestsTest < ActionDispatch::IntegrationTest
 
   test "the request id is set" do
     assert_empty Peek.adapter.requests
+
     get '/'
+
     assert_not_empty Peek.adapter.requests
+  end
+
+  test "the request ID and data are set correctly for concurrent requests" do
+    Peek.into TestView
+    concurrent_requests = 10
+
+    assert_empty Peek.adapter.requests
+
+    concurrent_requests.times.map do
+      Thread.new { get '/' }
+    end.map(&:join)
+
+    result_sequence = Peek.adapter.requests.values.map { |value| value[:data]['test-view'][:number] }
+
+    assert_equal Peek.adapter.requests.length, concurrent_requests
+    assert_equal result_sequence, 1.upto(concurrent_requests).to_a
   end
 end

--- a/test/dummy/lib/test_view.rb
+++ b/test/dummy/lib/test_view.rb
@@ -4,13 +4,11 @@ class TestView < Peek::Views::View
   class << self
     attr_accessor :counter
   end
-  self.counter = Concurrent::AtomicReference.new(0)
+  self.counter = Concurrent::AtomicFixnum.new
 
   def results
-    self.class.counter.update { |value| value + 1 }
-
     {
-      number: self.class.counter.value
+      number: self.class.counter.increment
     }
   end
 


### PR DESCRIPTION
When using Peek with a multithreaded application server (like Puma),
Peek.request_id was a problem: it was itself an atomic reference, but it
could be updated by multiple requests before they needed to read it. The
flow was:

1. Requests starts.
2. Set Peek.request_id from Rails' request ID.
3. Perform request.
4. Save results using Peek.request_id.
5. Clear Peek.request_id.

Another thread could do steps 2 or 5 for a different request before step
4 happened for 'this' request.

As Peek uses ActiveSupport instrumentation, and the
`process_action.action_controller` event has access to the request
details, we actually didn't need Peek.request_id at all: we can pass the
ID from the request to the adapter's `#save` method directly.

- - -

While this is a breaking change, I couldn't find anything else in peek/ using Peek.request_id: https://github.com/search?q="peek.request_id"+user%3Apeek&type=Code

- - -

(The first commit here is optional; it just makes the intent of the test view slightly clearer.)