### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/peek.gemspec
+++ b/peek.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/peek/peek'
   gem.license       = 'MIT'
 
+  gem.metadata      = {
+    'bug_tracker_uri'   => 'https://github.com/peek/peek/issues',
+    'changelog_uri'     => "https://github.com/peek/peek/blob/v#{gem.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/peek/#{gem.version}",
+    'source_code_uri'   => "https://github.com/peek/peek/tree/v#{gem.version}",
+  }
+
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/peek and be available via the rubygems API after the next release.