### PR TITLE
introduce Rails.cache adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Peeked::Application.configure do
     type: 'peek_request'
   }
 
+  # Cache with no options
+  config.peek.adapter = :cache
+
+  # Cache with options
+  config.peek.adapter = :cache, {
+    cache: Rails.cache,
+    expires_in: 60 * 30 # => 30 minutes in seconds
+  }
+
   # ...
 end
 ```

--- a/lib/peek/adapters/cache.rb
+++ b/lib/peek/adapters/cache.rb
@@ -1,0 +1,22 @@
+require 'peek/adapters/base'
+
+module Peek
+  module Adapters
+    class Cache < Base
+      def initialize(options = {})
+        @cache = options.fetch(:cache, Rails.cache)
+        @expires_in = Integer(options.fetch(:expires_in, 60 * 30))
+      end
+
+      def get(request_id)
+        @cache.read("peek:requests:#{request_id}")
+      end
+
+      def save(request_id)
+        return false if request_id.blank?
+
+        @cache.write("peek:requests:#{request_id}", Peek.results.to_json, expires_in: @expires_in)
+      end
+    end
+  end
+end

--- a/test/peek/adapters/cache_test.rb
+++ b/test/peek/adapters/cache_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require 'peek/adapters/cache'
+
+describe Peek::Adapters::Cache do
+  before do
+    Peek.reset
+    Rails.cache.clear
+  end
+
+  describe "get" do
+    before do
+      @adapter = Peek::Adapters::Cache.new
+      @request_id = 'dummy_request_id'
+    end
+
+    it "should return nil by default" do
+      assert_nil @adapter.get(@request_id)
+    end
+
+    it "should return an empty result from an empty save" do
+      @adapter.save(@request_id)
+      assert_equal '{"context":{},"data":{}}', @adapter.get(@request_id)
+    end
+  end
+end


### PR DESCRIPTION
This patch introduces a new adapter for `Rails.cache`.

The main goal here is to support compression of large values -- in particular for redis. Instead of adding compression support to the redis adapter ([patch](https://github.com/peek/peek/compare/master...igorwwwwwwwwwwwwwwwwwwww:compress)), we can delegate that to `Rails.cache`, which has support for compression on a higher level.

We saw at @gitlab that we're storing some pretty large values from peek. Compressing them should help avoid large keys. Not only does it save memory, it also avoids an imbalanced workload -- which can put significant pressure on redis during bursts.