### PR TITLE
Do not persist request id in Rails 4.2

### DIFF
--- a/lib/peek/railtie.rb
+++ b/lib/peek/railtie.rb
@@ -20,7 +20,7 @@ module Peek
 
     initializer 'peek.persist_request_data' do
       ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, _start, _finish, _id, payload|
-        if request_id = payload[:headers].env['action_dispatch.request_id']
+        if payload[:headers] && request_id = payload[:headers].env['action_dispatch.request_id']
           Peek.adapter.save(request_id)
         end
       end


### PR DESCRIPTION
See: https://github.com/peek/peek/issues/116

In Rails 4.2, some notification payloads do not include headers.

I'm not entirely sure how to run the tests against the 4.2 Gemfile, but
I was able to figure out how to bypass the exception gently.

If someone wants to point me towards how to actually solve the problem,
I'd be down to try it!